### PR TITLE
Add keyword splat to @transcode_options

### DIFF
--- a/lib/xz/stream_reader.rb
+++ b/lib/xz/stream_reader.rb
@@ -250,7 +250,7 @@ class XZ::StreamReader < XZ::Stream
       # Now, transcode it to the internal encoding if that was requested.
       # Otherwise return it with the external encoding as-is.
       if @internal_encoding
-        @readbuf.encode!(@internal_encoding, @transcode_options)
+        @readbuf.encode!(@internal_encoding, **@transcode_options)
         outbuf.force_encoding(@internal_encoding)
       else
         outbuf.force_encoding(@external_encoding)


### PR DESCRIPTION
(Note: original request was https://github.com/Quintus/ruby-xz/pull/19, but the repo has since changed hands)

At least on ruby3.0.0p0, the String#encode! doesn't take a Hash as its second argument, it expects keywords instead.

`rake test` has this to say about the issue:
```
  1) Error:
StreamReaderTest#test_encodings:
TypeError: no implicit conversion of Hash into String
    /Users/alexg/Dropbox/Programming/Projects/ruby-xz/lib/xz/stream_reader.rb:253:in `encode!'
    /Users/alexg/Dropbox/Programming/Projects/ruby-xz/lib/xz/stream_reader.rb:253:in `read'
    /Users/alexg/Dropbox/Programming/Projects/ruby-xz/test/test_stream_reader.rb:189:in `block in test_encodings'
    /Users/alexg/Dropbox/Programming/Projects/ruby-xz/lib/xz/stream_reader.rb:96:in `open'
    /Users/alexg/Dropbox/Programming/Projects/ruby-xz/test/test_stream_reader.rb:188:in `test_encodings'
```

This PR makes this test pass :)