### PR TITLE
Add Fiddle.free where appropriate to close memory leaks

### DIFF
--- a/lib/xz.rb
+++ b/lib/xz.rb
@@ -218,8 +218,10 @@ module XZ
       end
 
       LibLZMA.lzma_end(stream.to_ptr)
+      res = stream.total_out if block_given?
 
-      block_given? ? stream.total_out : res
+      Fiddle.free stream.to_ptr
+      res
     end
     alias decode_stream decompress_stream
 
@@ -317,8 +319,10 @@ module XZ
       end
 
       LibLZMA.lzma_end(stream.to_ptr)
+      res = stream.total_out if block_given?
 
-      block_given? ? stream.total_out : res
+      Fiddle.free stream.to_ptr
+      res
     end
     alias encode_stream compress_stream
 
@@ -458,8 +462,8 @@ module XZ
     # time--this is needed to allow (de-)compressing of very large
     # files that can't be loaded fully into memory.
     def lzma_code(io, stream)
-      input_buffer_p  = Fiddle::Pointer.malloc(CHUNK_SIZE) # automatically freed by fiddle on GC
-      output_buffer_p = Fiddle::Pointer.malloc(CHUNK_SIZE) # automatically freed by fiddle on GC
+      input_buffer_p  = Fiddle::Pointer.malloc(CHUNK_SIZE)
+      output_buffer_p = Fiddle::Pointer.malloc(CHUNK_SIZE)
 
       while str = io.read(CHUNK_SIZE)
         input_buffer_p[0, str.bytesize] = str
@@ -502,6 +506,9 @@ module XZ
           break unless stream.avail_out == 0
         end #loop
       end #while
+
+      Fiddle.free input_buffer_p
+      Fiddle.free output_buffer_p
     end #lzma_code
 
     # Checks for errors and warnings that can be derived from the

--- a/lib/xz/stream.rb
+++ b/lib/xz/stream.rb
@@ -155,9 +155,9 @@ class XZ::Stream
     # Reset internal state
     @pos = @lineno = 0
     @finished = false
-
-    # Allocate a new lzma stream (subclasses will configure it).
     @lzma_stream = XZ::LibLZMA::LZMAStream.malloc
+    @input_buffer_p  = Fiddle::Pointer.malloc(XZ::CHUNK_SIZE)
+    @output_buffer_p = Fiddle::Pointer.malloc(XZ::CHUNK_SIZE)
     XZ::LibLZMA::LZMA_STREAM_INIT(@lzma_stream)
 
     0 # Mimic IO#rewind's return value
@@ -211,6 +211,9 @@ class XZ::Stream
     # Clean up the lzma_stream structure's internal memory.
     # This would belong into a destructor if Ruby had that.
     XZ::LibLZMA.lzma_end(@lzma_stream)
+    Fiddle.free @lzma_stream.to_ptr
+    Fiddle.free @input_buffer_p
+    Fiddle.free @output_buffer_p
     @finished = true
 
     @delegate_io


### PR DESCRIPTION
Verified that this closes all the leaks for at least `XZ.compress_stream` and `XZ.decompress_stream`. via https://gist.github.com/win93/13693df4e12e0745793a03189e987f72.

On my machine, after a while, it settles out and the vast majority of outputs report no change in memory usage.

Also found and closed analogous leaks in the StreamReader and StreamWriter implementations.

Closes #2. (see the original issue at https://github.com/Quintus/ruby-xz/issues/20)